### PR TITLE
Add jmxtrans server attribute 'alias'

### DIFF
--- a/templates/default/set1.json.erb
+++ b/templates/default/set1.json.erb
@@ -9,6 +9,7 @@
   {
    "numQueryThreads": <%= server['numQueryThreads'] || 2 %>,
    "host": "<%= server['name'] %>",
+   "alias": "<%= server['alias'] %>",
    "username": "<%= server['username'] %>",
    "password": "<%= server['password'] %>",
    "port": <%= server['port'] %>,


### PR DESCRIPTION
This will allow users to define an alias for the monitored server and populate the JMX data generated.
