### PR TITLE
setting jmxtrans_opts to be configurable and exported into env 

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,6 +7,7 @@ default['jmxtrans']['user'] = 'jmxtrans'
 default['jmxtrans']['url'] = 'https://github.com/downloads/jmxtrans/jmxtrans/jmxtrans-20120525-210643-4e956b1144.zip'
 default['jmxtrans']['checksum'] = '0a5a2c361cc666f5a7174e2c77809e1a973c3af62868d407c68beb892f1b0217'
 default['jmxtrans']['heap_size'] = '512'
+default['jmxtrans']['jmxtrans_opts'] = nil
 default['jmxtrans']['run_interval'] = '60'
 default['jmxtrans']['log_level'] = 'debug'
 default['jmxtrans']['graphite']['host'] = 'graphite'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email "gs.biju at gmail.com"
 license          "Apache 2.0"
 description      "Installs/Configures jmxtrans"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.1.0"
+version          "1.2.0"
 
 depends "ark"

--- a/templates/default/jmxtrans_default.erb
+++ b/templates/default/jmxtrans_default.erb
@@ -14,4 +14,6 @@ export NEW_SIZE=64
 export CPU_CORES=<%= node['cpu']['total'] %>
 export NEW_RATIO=8
 export LOG_LEVEL=<%= node['jmxtrans']['log_level'] %>
-
+<% if node['jmxtrans']['jmxtrans_opts'] %>
+export JMXTRANS_OPTS='<%= node['jmxtrans']['jmxtrans_opts'] %>'
+<% end %>


### PR DESCRIPTION
This PR resolves this issue https://github.com/jmxtrans/jmxtrans-cookbook/issues/12. 

Somewhat related to: https://github.com/jmxtrans/jmxtrans/issues/296

This should be a no-op and by that I mean I default the value to nil so unless explicitly set in a wrapper cookbook or otherwise this new behavior will not impact legacy in any way. 
