### PR TITLE
override default [ "name" ] in typeName

### DIFF
--- a/templates/default/set1.json.erb
+++ b/templates/default/set1.json.erb
@@ -23,7 +23,7 @@
       {
        "@class": "com.googlecode.jmxtrans.model.output.GraphiteWriter",
        "settings": {
-        "typeNames": [   "name" ],
+        "typeNames": <%= if query.has_key?('type_name') then query['type_name'].to_s else [ "name" ] end%>,
         "host": "<%= @graphite_host %>",
         "port": <%= @graphite_port %>,
         "rootPrefix": "<%= @root_prefix %>"


### PR DESCRIPTION
This is useful in places where stats compose of a tree with repeating attribute names such as queue usage statistics in [YARN](https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/YARN.html) ResourceManager.  When transported to Graphite it would be user friendly to see a separate branch for each user's usage statistics. 

Such a query may be composed in the following way after this change:

``` ruby
default['jmxtrans']['default_queries']['resourcemanager'] = [
  {
    'type_name' => ["name", "q0", "user"],
    'obj' => "Hadoop:service=ResourceManager,name=QueueMetrics,q0=root,user=*",
    'result_alias' => "ResourceManager",
    'attr' => [
                "AppsRunning",
                "AppsPending",
                "AllocatedMB",
                "AllocatedVCores",
                "AllocatedContainers",
                "PendingMB",
                "PendingVCores",
                "PendingContainers",
                "ReservedMB",
                "ReservedVCores",
                "ReservedContainers",
                "ActiveUsers",
                "ActiveApplications"
        ]
  }
]
```
