### PR TITLE
Changes to default attributes so that they are more user friendly

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,11 +1,11 @@
 default['jmxtrans']['install_prefix'] = '/opt'
-default['jmxtrans']['java_home'] = '/usr/bin/java'
+default['jmxtrans']['java_home'] = nil
 default['jmxtrans']['home'] = "#{default['jmxtrans']['install_prefix']}/jmxtrans"
 default['jmxtrans']['json_dir'] = "#{default['jmxtrans']['home']}/json"
 default['jmxtrans']['log_dir'] = '/var/log/jmxtrans'
 default['jmxtrans']['version'] = '250'
 default['jmxtrans']['user'] = 'jmxtrans'
-default['jmxtrans']['url'] = 'http://central.maven.org/maven2/org/jmxtrans/jmxtrans/'
+default['jmxtrans']['url'] = "http://central.maven.org/maven2/org/jmxtrans/jmxtrans/#{default['jmxtrans']['version']}"
 default['jmxtrans']['checksum'] = '0a5a2c361cc666f5a7174e2c77809e1a973c3af62868d407c68beb892f1b0217'
 default['jmxtrans']['heap_size'] = '512'
 default['jmxtrans']['run_interval'] = '60'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,7 +38,7 @@ servers.each do |server|
 end
 
 ark "jmxtrans" do
-  url "#{node['jmxtrans']['url']}/#{node['jmxtrans']['version']}/jmxtrans-#{node['jmxtrans']['version']}-dist.tar.gz"
+  url "#{node['jmxtrans']['url']}/jmxtrans-#{node['jmxtrans']['version']}-dist.tar.gz"
   #checksum node['jmxtrans']['checksum']
   version node['jmxtrans']['version']
   prefix_root '/opt'

--- a/templates/default/jmxtrans_default.erb
+++ b/templates/default/jmxtrans_default.erb
@@ -1,4 +1,4 @@
-<% if node['jmxtrans']['java_home'] %>
+<% if !node['jmxtrans']['java_home'].nil? %>
 export JAVA_HOME=<%= node['jmxtrans']['java_home'] %>
 <% end %>
 export JAR_FILE='<%= "#{node['jmxtrans']['home']}/jmxtrans-all.jar" %>'


### PR DESCRIPTION
The changes in this PR includes
- Setting the default value for `default['jmxtrans']['java_home']` to `nil` so that the value set in the `JAVA_HOME` environment variable will be used if the attribute value is not overwritten by the user.
- Change the default value for `default['jmxtrans']['url']` so that the JMXTrans version is part of the URL attribute value. The version value was appended in the `default` recipe which creates issues if user want to pass their own URL.
